### PR TITLE
fix: use unloadedPoints and visiblePoints to calculate load percentage

### DIFF
--- a/src/potree.ts
+++ b/src/potree.ts
@@ -170,6 +170,7 @@ export class Potree implements IPotree {
     );
 
     let loadedToGPUThisFrame = 0;
+    let numUnloadedPoints = 0;
     let exceededMaxLoadsToGPU = false;
     let nodeLoadFailed = false;
     let queueItem: QueueItem | undefined;
@@ -209,6 +210,7 @@ export class Potree implements IPotree {
             exceededMaxLoadsToGPU = true;
           }
           unloadedGeometry.push(node);
+          numUnloadedPoints += node.numPoints;
           pointCloud.visibleGeometry.push(node);
         } else {
           nodeLoadFailed = true;
@@ -244,7 +246,7 @@ export class Potree implements IPotree {
     return {
       visibleNodes: visibleNodes,
       numVisiblePoints: numVisiblePoints,
-      numUnloadedGeometry: unloadedGeometry.length,
+      numUnloadedPoints: numUnloadedPoints,
       exceededMaxLoadsToGPU: exceededMaxLoadsToGPU,
       nodeLoadFailed: nodeLoadFailed,
       nodeLoadPromises: nodeLoadPromises,

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,7 +38,7 @@ export interface IPointCloudGeometryNode extends IPointCloudTreeNode {
 export interface IVisibilityUpdateResult {
   visibleNodes: IPointCloudTreeNode[];
   numVisiblePoints: number;
-  numUnloadedGeometry: number;
+  numUnloadedPoints: number;
   /**
    * True when a node has been loaded but was not added to the scene yet.
    * Make sure to call updatePointClouds() again on the next frame.


### PR DESCRIPTION
As discussed, we can use unloadedPoints and visiblePoints to get a more accurate loading percentage. It's pretty clear why this is a better approach - for example, numUnloadedPoints will never exceed numVisiblePoints because we will always increase numVisiblePoints by at least the same amount as numUnloadedPoints.